### PR TITLE
fix double set-cookie header issue in prod

### DIFF
--- a/backend/controllers/auth.js
+++ b/backend/controllers/auth.js
@@ -17,7 +17,7 @@ exports.registerUser = async (req, res) => {
 
   res
     .status(201)
-    .setHeader("Set-Cookie", `FarmWiseKey=${jwtToken}`)
+    .setHeader("JWTAuthToken", `FarmWiseKey=${jwtToken}`)
     .json(formatSuccessResponse(createdUser));
 };
 
@@ -34,7 +34,7 @@ exports.loginUser = async (req, res) => {
 
   res
     .status(200)
-    .setHeader("Set-Cookie", `FarmWiseKey=${jwtToken}`)
+    .setHeader("JWTAuthToken", `FarmWiseKey=${jwtToken}`)
     .json(formatSuccessResponse(user));
 };
 


### PR DESCRIPTION
were seeing two `set-cookie` header in production, causing trouble with header parsing in the UI. 

modifies our own header to use a different name